### PR TITLE
Adapting after refactoring

### DIFF
--- a/ajmc/data/templates/alto.xml.jinja2
+++ b/ajmc/data/templates/alto.xml.jinja2
@@ -5,7 +5,7 @@
       <Description>
           <MeasurementUnit>pixel</MeasurementUnit>
           <sourceImageInformation>
-              <fileName>{{ page.image.path.split('/')[-1] }}</fileName>
+              <fileName>{{ page.image.path.name}}</fileName>
           </sourceImageInformation>
       </Description>
 

--- a/ajmc/text_processing/canonical_classes.py
+++ b/ajmc/text_processing/canonical_classes.py
@@ -67,7 +67,7 @@ class CanonicalCommentary(Commentary):
         commentary = cls(id=can_json['id'],
                          children=None,
                          images=None,
-                         ocr_run=can_json['ocr_run'],
+                         ocr_run=can_json['ocr_run_id'],
                          ocr_gt_page_ids=can_json['ocr_gt_page_ids'])
 
         # Automatically determinates paths


### PR DESCRIPTION
The notebook I had (in the GDrive) for Segmonto Alto export was broken after the latest refactoring. The changes in this PR adapt that code to the refactored canonical classes and format. 